### PR TITLE
Bump markdown version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
 
 		"symfony/finder": "2.3.*",
 
-		"dflydev/markdown": "v1.0.2",
+		"dflydev/markdown": "v1.0.3",
 
 		"daylerees/kurenai": "1.0.*"
 	},


### PR DESCRIPTION
Markdown has been updated to fix a security issue https://github.com/dflydev/dflydev-markdown/releases/tag/v1.0.3
